### PR TITLE
Crude fix for poorly behaved pvalue distribution

### DIFF
--- a/R/findCorrelation.R
+++ b/R/findCorrelation.R
@@ -104,7 +104,11 @@ findCorrelation <- function(object, method = "pearson", adj.pval = FALSE,
     allCortab <- do.call(rbind, lapply(allX, function(x) x))
 
     if (adj.pval) {
-        qvals <- qvalue(allCortab$pvalue)
+        qvals <- tryCatch({
+            qvalue(corData$pvalue)
+        }, error = function(e) {
+            qvalue(corData$pvalue, pi0=1)
+        })
         allCortab <- cbind(allCortab, qvals$qvalues)
         colnames(allCortab)[9] <- "qvalue"
     }

--- a/R/findCorrelation.R
+++ b/R/findCorrelation.R
@@ -105,9 +105,9 @@ findCorrelation <- function(object, method = "pearson", adj.pval = FALSE,
 
     if (adj.pval) {
         qvals <- tryCatch({
-            qvalue(corData$pvalue)
+            qvalue(allCortab$pvalue)
         }, error = function(e) {
-            qvalue(corData$pvalue, pi0=1)
+            qvalue(allCortab$pvalue, pi0=1)
         })
         allCortab <- cbind(allCortab, qvals$qvalues)
         colnames(allCortab)[9] <- "qvalue"


### PR DESCRIPTION
Fixes: #4 
TODO: send the user a sensible warning that their pvalues are poorly behaved.

The qvalue package fails ungracefully when the pvalue distribution you hand it is poorly behaved or not very large. See 
https://github.com/StoreyLab/qvalue/issues/11
or 
https://github.com/StoreyLab/qvalue/commit/f534759bdc462d672744a29230017c9a346021fa#commitcomment-26274105
for details. 
This is a crude fix to prevent InTAD from failing, and uses a crude pi0=1 parameter to badly estimate qvalues anyway.